### PR TITLE
Update fstab.samsungexynos8890

### DIFF
--- a/builds/TW-PIE/ramdisk/fstab.samsungexynos8890
+++ b/builds/TW-PIE/ramdisk/fstab.samsungexynos8890
@@ -2,16 +2,14 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-#<src>                                                  <mnt_point> <type>  <mnt_flags and options>                                                                                                     <fs_mgr_flags>
-/dev/block/platform/155a0000.ufs/by-name/SYSTEM         /system     ext4    ro,barrier=1                                                                                                                wait
-/dev/block/platform/155a0000.ufs/by-name/SYSTEM         /system     f2fs    ro,noatime,noload                                                                                                           wait
-/dev/block/platform/155a0000.ufs/by-name/CACHE          /cache      ext4    noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic                                 wait,check
-/dev/block/platform/155a0000.ufs/by-name/CACHE          /cache      f2fs    rw,nosuid,nodev,noatime,inline_xattr,flush_merge,nobarrier                                                                  wait,check,formattable
-/dev/block/platform/155a0000.ufs/by-name/USERDATA       /data       ext4    noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic,debug_bdinfo     		        wait,check,encryptable=footer,quota
-/dev/block/platform/155a0000.ufs/by-name/USERDATA       /data       f2fs    rw,nosuid,nodev,noatime,inline_xattr,flush_merge,nobarrier,fsync_mode=nobarrier                                             latemount,wait,check,encryptable=footer,formattable,length=-16384
-/dev/block/platform/155a0000.ufs/by-name/EFS            /efs        ext4    noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic                                 wait,check
+#<src>                                                      <mnt_point>    <type>    <mnt_flags and options>                                                                        <fs_mgr_flags>
+/dev/block/platform/155a0000.ufs/by-name/SYSTEM             /system        ext4      ro,barrier=1                                                                                   wait
+/dev/block/platform/155a0000.ufs/by-name/CACHE              /cache         ext4      noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic    wait,check
+/dev/block/platform/155a0000.ufs/by-name/USERDATA           /data          f2fs      nosuid,nodev,noatime,discard,fsync_mode=nobarrier                                              latemount,wait,check,encryptable=footer,formattable,length=-16384
+/dev/block/platform/155a0000.ufs/by-name/USERDATA           /data          ext4      noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic    latemount,wait,check,encryptable=footer,quota
+/dev/block/platform/155a0000.ufs/by-name/EFS                /efs           ext4      noatime,nosuid,nodev,noauto_da_alloc,discard,journal_async_commit,data=ordered,errors=panic    wait,check
 
 # VOLD :: fstab.gracerlte
-/dev/block/platform/155a0000.ufs/by-name/HIDDEN          /preload    ext4    defaults    voldmanaged=preload:auto
-/devices/15740000.dwmmc2/mmc_host/mmc*                       auto    vfat    defaults    voldmanaged=sdcard:auto
-/devices/15400000.usb/15400000.dwc3/xhci-hcd.2.auto/usb*     auto    auto    defaults    voldmanaged=usb:auto
+/dev/block/platform/155a0000.ufs/by-name/HIDDEN             /preload       ext4      defaults                                                                                       voldmanaged=preload:auto
+/devices/15740000.dwmmc2/mmc_host/mmc*                      auto           vfat      defaults                                                                                       voldmanaged=sdcard:auto
+/devices/15400000.usb/15400000.dwc3/xhci-hcd.2.auto/usb*    auto           vfat      defaults                                                                                       voldmanaged=usb:auto


### PR DESCRIPTION
Remove f2fs mounting on Cache and System since its useless
Try f2fs for userdata first to speed up boot
Correct type for usb to vfat
Correct mount options for ext4
Tab aligned layout of the file